### PR TITLE
fix(scraper): add `brand` as a primary attribute in the product schema

### DIFF
--- a/packages/scraper/src/__tests__/amazon.test.ts
+++ b/packages/scraper/src/__tests__/amazon.test.ts
@@ -19,6 +19,7 @@ describe('AmazonScraper', () => {
       const result = scraper.getProduct();
       expect(result).toEqual({
         name: 'Tarcury WW2 F4U Corsair Fighter Bomber Building Bricks - 550 PCS Army Toy Set with 1 Toy Soldiers - Engaging WWII Toys for Kids and Adults',
+        brand: 'Tarcury',
         price: 29.99,
         currency: 'CAD',
         images: [

--- a/packages/scraper/src/__tests__/index.test.ts
+++ b/packages/scraper/src/__tests__/index.test.ts
@@ -75,12 +75,12 @@ describe('Scraper Module', () => {
       expect(product).toEqual({
         url: 'https://example.com/product',
         name: 'Test Product JSON-LD',
+        brand: 'Test Brand',
         description: 'Product JSON-LD description',
         images: [{ url: 'https://example.com/image.jpg' }],
         price: 89.99,
         currency: 'CAD',
         metadata: {
-          brand: 'Test Brand',
           '@context': 'https://schema.org/',
           '@type': 'Product',
           offers: {
@@ -106,7 +106,7 @@ describe('Scrapper Module with SSENSE', () => {
     html = fs.readFileSync(htmlFilePath, 'utf-8');
   });
 
-  describe('useScraper', () => {
+  describe('getProduct', () => {
     it('should return a product and no error for valid input', () => {
       const [product, error] = getProduct(url, html);
 
@@ -117,6 +117,7 @@ describe('Scrapper Module with SSENSE', () => {
 
       expect(product).toEqual({
         name: 'Black Jersey Crewneck T-shirt',
+        brand: 'Fear of God ESSENTIALS',
         description: expectedDescription,
         images: [
           {
@@ -132,7 +133,6 @@ describe('Scrapper Module with SSENSE', () => {
         metadata: {
           '@context': 'https://schema.org',
           '@type': 'Product',
-          brand: 'Fear of God ESSENTIALS',
           productID: 16693101,
           sku: '251161M213015',
           offers: {

--- a/packages/scraper/src/__tests__/jsonld.test.ts
+++ b/packages/scraper/src/__tests__/jsonld.test.ts
@@ -52,12 +52,12 @@ describe('ProductScraper', () => {
       const result = scraper.getProduct();
       expect(result).toEqual({
         name: 'Test Product JSON-LD',
+        brand: 'Test Brand',
         description: 'Product JSON-LD description',
         images: [{ url: 'https://example.com/image.jpg' }],
         price: 89.99,
         currency: 'EUR',
         metadata: {
-          brand: 'Test Brand',
           '@context': 'https://schema.org/',
           '@type': 'Product',
           offers: {
@@ -135,6 +135,7 @@ describe('JsonLdScraper with SSENSE', () => {
 
       expect(jsonLd).toEqual({
         name: 'Black Jersey Crewneck T-shirt',
+        brand: 'Fear of God ESSENTIALS',
         description: expectedDescription,
         images: [
           {
@@ -146,7 +147,6 @@ describe('JsonLdScraper with SSENSE', () => {
         metadata: {
           '@context': 'https://schema.org',
           '@type': 'Product',
-          brand: 'Fear of God ESSENTIALS',
           productID: 16693101,
           sku: '251161M213015',
           offers: {

--- a/packages/scraper/src/__tests__/opengraph.test.ts
+++ b/packages/scraper/src/__tests__/opengraph.test.ts
@@ -14,25 +14,10 @@ describe('OpenGraphScraper', () => {
         <meta property="og:description" content="Product description" />
         <meta property="og:url" content="https://example.com/product" />
         <meta property="og:image" content="https://example.com/image.jpg" />
+        <meta property="product:brand" content="Example Brand"/>
         <meta property="product:price:amount" content="99.99" />
         <meta property="product:price:currency" content="USD" />
         <link rel="icon" href="favicon.ico" />
-        <script type="application/ld+json">
-          {
-            "@context": "https://schema.org/",
-            "@type": "Product",
-            "name": "Test Product JSON-LD",
-            "description": "Product JSON-LD description",
-            "image": "https://example.com/image.jpg",
-            "brand": {
-              "name": "Test Brand"
-            },
-            "offers": {
-              "price": "89.99",
-              "priceCurrency": "EUR"
-            }
-          }
-        </script>
       </head>
       <body></body>
     </html>
@@ -49,6 +34,7 @@ describe('OpenGraphScraper', () => {
       const result = scraper.getProduct();
       expect(result).toEqual({
         name: 'Test Product OG',
+        brand: 'Example Brand',
         description: 'Product description',
         images: [{ url: 'https://example.com/image.jpg' }],
         price: 99.99,
@@ -86,6 +72,7 @@ describe('OpenGraphScraper with SSENSE', () => {
 
       expect(metadata).toEqual({
         name: 'Fear of God ESSENTIALS - Black Jersey Crewneck T-shirt',
+        brand: 'Fear of God ESSENTIALS',
         description: expectedDescription,
         images: [
           {
@@ -98,7 +85,6 @@ describe('OpenGraphScraper with SSENSE', () => {
           url: 'https://www.ssense.com/en-ca/en-ca/men/product/essentials/black-jersey-crewneck-t-shirt/16693101',
           favicon:
             'https://res.cloudinary.com/ssenseweb/image/upload/v1472005257/web/favicon.ico',
-          brand: 'Fear of God ESSENTIALS',
         },
       });
     });

--- a/packages/scraper/src/amazon.ts
+++ b/packages/scraper/src/amazon.ts
@@ -24,6 +24,13 @@ export default class AmazonScraper implements Scraper {
       },
     ]);
 
+    const brand = findBySelectors(this.$, [
+      {
+        selector:
+          '#productOverview_feature_div table tbody tr.po-brand td:nth-child(2) span',
+      },
+    ]);
+
     const price = findBySelectors(this.$, [
       {
         selector: '#priceValue',
@@ -63,6 +70,7 @@ export default class AmazonScraper implements Scraper {
 
     const product = {
       name,
+      brand,
       images: imageURL ? [{ url: imageURL }] : null,
       price: parseNum(price),
       currency: parseCurrency(currency),

--- a/packages/scraper/src/jsonld.ts
+++ b/packages/scraper/src/jsonld.ts
@@ -35,12 +35,12 @@ export default class JsonLdScraper implements Scraper {
 
     const product = {
       name,
+      brand: brand?.name,
       description,
       images: imageURL ? [{ url: imageURL }] : null,
       price: getJsonLdPrice(jsonLd),
       currency: getJsonLdCurrency(jsonLd),
       metadata: {
-        brand: brand?.name,
         url: parseURL(url, this.url.hostname),
         ...metadata,
       },

--- a/packages/scraper/src/lib/utils.ts
+++ b/packages/scraper/src/lib/utils.ts
@@ -13,6 +13,7 @@ export const mergeProducts = (products: Product[]): Product => {
 
   for (const p of products) {
     product.name = product.name ?? p.name;
+    product.brand = product.brand ?? p.brand;
     product.description = product.description ?? p.description;
     product.price = product.price ?? p.price;
     product.currency = product.currency ?? p.currency;

--- a/packages/scraper/src/microdata.ts
+++ b/packages/scraper/src/microdata.ts
@@ -23,6 +23,16 @@ export default class MicrodataScraper implements Scraper {
       },
     ]);
 
+    const brand = findBySelectors(this.$, [
+      {
+        selector: '[itemType*=Product] [itemProp=brand]',
+        attribute: 'content',
+      },
+      {
+        selector: '[itemType*=Product] [itemProp=brand]',
+      },
+    ]);
+
     const description = findBySelectors(this.$, [
       {
         selector: '[itemType*=Product] [itemProp=description]',
@@ -66,6 +76,7 @@ export default class MicrodataScraper implements Scraper {
 
     const product = {
       name,
+      brand,
       description,
       images: imageURL ? [{ url: imageURL }] : null,
       price: parseNum(price),

--- a/packages/scraper/src/opengraph.ts
+++ b/packages/scraper/src/opengraph.ts
@@ -19,6 +19,11 @@ export default class OpenGraphScraper implements Scraper {
       { selector: 'title' },
     ]);
 
+    const brand = findBySelectors(this.$, [
+      { selector: 'meta[property="product:brand"]', attribute: 'content' },
+      { selector: 'meta[property="og:brand"]', attribute: 'content' },
+    ]);
+
     const description = findBySelectors(this.$, [
       { selector: 'meta[property="og:description"]', attribute: 'content' },
       { selector: 'meta[name="twitter:description"]', attribute: 'content' },
@@ -60,11 +65,6 @@ export default class OpenGraphScraper implements Scraper {
       { selector: 'link[rel="canonical"]', attribute: 'href' },
     ]);
 
-    const brand = findBySelectors(this.$, [
-      { selector: 'meta[property="og:brand"]', attribute: 'content' },
-      { selector: 'meta[property="product:brand"]', attribute: 'content' },
-    ]);
-
     const favicon = findBySelectors(this.$, [
       { selector: 'link[rel*="icon"]', attribute: 'href' },
       { selector: 'meta[name*="msapplication"]', attribute: 'content' },
@@ -74,6 +74,7 @@ export default class OpenGraphScraper implements Scraper {
 
     const product = {
       name,
+      brand,
       description,
       images: imageURL ? [{ url: imageURL }] : null,
       price: parseNum(price),
@@ -81,7 +82,6 @@ export default class OpenGraphScraper implements Scraper {
       metadata: {
         url,
         favicon,
-        brand,
       },
     };
 

--- a/packages/scraper/src/types.ts
+++ b/packages/scraper/src/types.ts
@@ -4,6 +4,7 @@ export interface Scraper {
 
 export type Product = {
   url?: string | null;
+  brand?: string | null;
   name?: string | null;
   price?: number | null;
   currency?: string | null;


### PR DESCRIPTION
This PR adds `brand` as a primary attribute in the product schema to support the updated UI design requirements.

### Scraper

* Modified scrapers to extract and return brand as a required field.
* Note: The `amazon` scrapers `brand` selection may be unstable as it relies on pure HTML selection, which can break when minor changes occur in the page structure.

### Test

* Added test cases to validate the inclusion of brand in scraper outputs.
