### PR TITLE
feat(scraper): allow passing custom selectors for product scraping

### DIFF
--- a/packages/scraper/package.json
+++ b/packages/scraper/package.json
@@ -3,7 +3,6 @@
   "type": "module",
   "scripts": {
     "dev": "tsc --watch",
-    "build": "tsc",
     "test": "jest"
   },
   "exports": {

--- a/packages/scraper/src/__tests__/amazon.test.ts
+++ b/packages/scraper/src/__tests__/amazon.test.ts
@@ -1,17 +1,18 @@
-import AmazonScraper from '../amazon';
 import fs from 'fs';
 import path from 'path';
+import { SiteScraper } from '..';
+import { amazonSelectors } from '../amazon';
 
 describe('AmazonScraper', () => {
   const url =
     'https://www.amazon.ca/Tarcury-Corsair-Fighter-Bomber-Building/dp/B0CNT488KH?pd_rd_w=QmenC&content-id=amzn1.sym.8eef7635-0ea1-468f-9bbf-a6c1163fd848&pf_rd_p=8eef7635-0ea1-468f-9bbf-a6c1163fd848&pf_rd_r=AN6A3DYMW5RSK3RCWZQN&pd_rd_wg=D3E9W&pd_rd_r=2d0f9aca-c2b3-4928-9b97-9e13695002f4&pd_rd_i=B0CNT488KH&ref_=pd_hp_d_btf_CACPN24_B0CNT488KH&th=1';
   let html: string;
-  let scraper: AmazonScraper;
+  let scraper: SiteScraper;
 
   beforeAll(() => {
     const htmlFilePath = path.resolve(__dirname, 'data/amazon.html');
     html = fs.readFileSync(htmlFilePath, 'utf-8');
-    scraper = new AmazonScraper(url, html);
+    scraper = new SiteScraper(url, html, amazonSelectors);
   });
 
   describe('getProduct', () => {

--- a/packages/scraper/src/__tests__/index.test.ts
+++ b/packages/scraper/src/__tests__/index.test.ts
@@ -1,30 +1,10 @@
+import { amazonSelectors } from '../amazon';
 import fs from 'fs';
 import path from 'path';
-import AmazonScraper from '../amazon';
-import { getProduct, SiteScraper } from '../index';
+import { getProduct } from '../index';
 import { normalizeText } from '../lib/utils';
 
 describe('Scraper Module', () => {
-  describe('SiteScraper', () => {
-    it('should return an instance of AmazonScraper for Amazon URLs', () => {
-      const url = 'https://www.amazon.com/example-product';
-      const html = '<html></html>';
-
-      const scraper = SiteScraper.create(url, html);
-
-      expect(scraper).toBeInstanceOf(AmazonScraper);
-    });
-
-    it('should return an instance of ProductScraper for non-Amazon URLs', () => {
-      const url = 'https://www.example.com/example-product';
-      const html = '<html></html>';
-
-      const scraper = SiteScraper.create(url, html);
-
-      expect(scraper).toBeInstanceOf(SiteScraper);
-    });
-  });
-
   describe('getProduct', () => {
     it('should return a product and no error for valid input', () => {
       const url = 'https://www.amazon.com/example-product';
@@ -165,7 +145,7 @@ describe('Scrapper Module with Amazon', () => {
 
   describe('getProduct', () => {
     it('should return a product and no error for valid input', () => {
-      const [product, error] = getProduct(url, html);
+      const [product, error] = getProduct(url, html, amazonSelectors);
       product!.description = normalizeText(product?.description);
 
       expect(product).toEqual({

--- a/packages/scraper/src/__tests__/selector.test.ts
+++ b/packages/scraper/src/__tests__/selector.test.ts
@@ -1,0 +1,37 @@
+import * as cheerio from 'cheerio';
+import { findBySelectors } from '../selector';
+
+describe('Selector Module', () => {
+  describe('findBySelectors', () => {
+    it('should find element by selectors', () => {
+      const html = '<div class="test">Hello</div>';
+      const $ = cheerio.load(html);
+      const selectors = [{ selector: '.test' }];
+      expect(findBySelectors($, selectors)).toBe('Hello');
+    });
+
+    it('should return undefined if no element is found', () => {
+      const html = '<div class="test">Hello</div>';
+      const $ = cheerio.load(html);
+      const selectors = [{ selector: '.not-found' }];
+      expect(findBySelectors($, selectors)).toBeUndefined();
+    });
+
+    it('should return the data-src from array of attribute', () => {
+      const html =
+        '<img src="src.jpg" data-src="data-src.jpg" srcset="srcset.jpg"/>';
+      const $ = cheerio.load(html);
+      const selectors = [
+        { selector: 'img', attribute: ['data-src', 'srcset'] },
+      ];
+      expect(findBySelectors($, selectors)).toEqual('data-src.jpg');
+    });
+
+    it('should return the src from array of attribute', () => {
+      const html = '<img src="src.jpg" srcset="srcset.jpg"/>';
+      const $ = cheerio.load(html);
+      const selectors = [{ selector: 'img', attribute: ['data-src', 'src'] }];
+      expect(findBySelectors($, selectors)).toEqual('src.jpg');
+    });
+  });
+});

--- a/packages/scraper/src/amazon.ts
+++ b/packages/scraper/src/amazon.ts
@@ -1,84 +1,44 @@
-import * as cheerio from 'cheerio';
-import { parseCurrency, parseNum, parseURL } from './lib/parse';
-import { findBySelectors, removeNullAndUndefined } from './lib/utils';
-import { Product, Scraper } from './types';
+import { Selector } from './selector';
 
-export default class AmazonScraper implements Scraper {
-  $: cheerio.CheerioAPI;
-  url: URL;
-
-  constructor(url: string, html: string) {
-    this.$ = cheerio.load(html);
-    this.url = new URL(url);
-  }
-
-  getProduct(): Product {
-    const name = findBySelectors(this.$, [
-      {
-        selector: '#productTitle',
-        attribute: 'value',
-      },
-      {
-        selector: '[name="productTitle"]',
-        attribute: 'value',
-      },
-    ]);
-
-    const brand = findBySelectors(this.$, [
-      {
-        selector:
-          '#productOverview_feature_div table tbody tr.po-brand td:nth-child(2) span',
-      },
-    ]);
-
-    const price = findBySelectors(this.$, [
-      {
-        selector: '#priceValue',
-        attribute: 'value',
-      },
-      {
-        selector: '[name="priceValue"]',
-        attribute: 'value',
-      },
-    ]);
-
-    const currency = findBySelectors(this.$, [
-      {
-        selector: '#currencyOfPreference',
-        attribute: 'value',
-      },
-      {
-        selector: '[name="currencyOfPreference"]',
-        attribute: 'value',
-      },
-    ]);
-
-    const image = findBySelectors(this.$, [
-      { selector: 'img#landingImage', attribute: 'src' },
-      { selector: '#imgTagWrapperId img', attribute: 'src' },
-      { selector: '[name="productImageUrl"]', attribute: 'value' },
-    ]);
-
-    const category = findBySelectors(this.$, [
-      {
-        selector: '#productCategory',
-        attribute: 'value',
-      },
-    ]);
-
-    const imageURL = parseURL(image, this.url.hostname);
-
-    const product = {
-      name,
-      brand,
-      images: imageURL ? [{ url: imageURL }] : null,
-      price: parseNum(price),
-      currency: parseCurrency(currency),
-      metadata: {
-        category,
-      },
-    };
-
-    return removeNullAndUndefined(product);
-  }
-}
+export const amazonSelectors: Record<string, Selector[]> = {
+  name: [
+    { selector: '#productTitle', attribute: 'value' },
+    {
+      selector: '[name="productTitle"]',
+      attribute: 'value',
+    },
+  ],
+  brand: [
+    {
+      selector:
+        '#productOverview_feature_div table tbody tr.po-brand td:nth-child(2) span',
+    },
+  ],
+  price: [
+    { selector: '#priceValue', attribute: 'value' },
+    {
+      selector: '[name="priceValue"]',
+      attribute: 'value',
+    },
+    { selector: '#dp .a-price span.a-offscreen' },
+    { selector: '#priceblock_ourprice' },
+  ],
+  currency: [
+    { selector: '#currencyOfPreference', attribute: 'value' },
+    {
+      selector: '[name="currencyOfPreference"]',
+      attribute: 'value',
+    },
+  ],
+  image: [
+    { selector: 'img#landingImage', attribute: 'src' },
+    { selector: '#imgTagWrapperId img', attribute: 'src' },
+    { selector: '[name="productImageUrl"]', attribute: 'value' },
+  ],
+  category: [
+    {
+      selector: '#productCategory',
+      attribute: 'value',
+    },
+  ],
+};

--- a/packages/scraper/src/jsonld.ts
+++ b/packages/scraper/src/jsonld.ts
@@ -33,7 +33,7 @@ export default class JsonLdScraper implements Scraper {
     const { name, description, brand, image, url, ...metadata } = jsonLd;
     const imageURL = parseURL(image, this.url.hostname);
 
-    const product = {
+    const product: Product = {
       name,
       brand: brand?.name,
       description,
@@ -46,7 +46,7 @@ export default class JsonLdScraper implements Scraper {
       },
     };
 
-    return removeNullAndUndefined(product) as Product;
+    return removeNullAndUndefined(product);
   }
 }
 

--- a/packages/scraper/src/lib/__tests__/utils.test.ts
+++ b/packages/scraper/src/lib/__tests__/utils.test.ts
@@ -1,11 +1,6 @@
 import { Product } from '../../types';
 import * as cheerio from 'cheerio';
-import {
-  findBySelectors,
-  mergeProducts,
-  normalizeText,
-  removeNullAndUndefined,
-} from '../utils';
+import { mergeProducts, normalizeText, removeNullAndUndefined } from '../utils';
 
 describe('Utils Module', () => {
   describe('mergeProducts', () => {
@@ -52,40 +47,7 @@ describe('Utils Module', () => {
     });
   });
 
-  describe('findBySelectors', () => {
-    it('should find element by selectors', () => {
-      const html = '<div class="test">Hello</div>';
-      const $ = cheerio.load(html);
-      const selectors = [{ selector: '.test' }];
-      expect(findBySelectors($, selectors)).toBe('Hello');
-    });
-
-    it('should return undefined if no element is found', () => {
-      const html = '<div class="test">Hello</div>';
-      const $ = cheerio.load(html);
-      const selectors = [{ selector: '.not-found' }];
-      expect(findBySelectors($, selectors)).toBeUndefined();
-    });
-
-    it('should return the data-src from array of attribute', () => {
-      const html =
-        '<img src="src.jpg" data-src="data-src.jpg" srcset="srcset.jpg"/>';
-      const $ = cheerio.load(html);
-      const selectors = [
-        { selector: 'img', attribute: ['data-src', 'srcset'] },
-      ];
-      expect(findBySelectors($, selectors)).toEqual('data-src.jpg');
-    });
-
-    it('should return the src from array of attribute', () => {
-      const html = '<img src="src.jpg" srcset="srcset.jpg"/>';
-      const $ = cheerio.load(html);
-      const selectors = [{ selector: 'img', attribute: ['data-src', 'src'] }];
-      expect(findBySelectors($, selectors)).toEqual('src.jpg');
-    });
-  });
-
-  describe('sanitizeObject', () => {
+  describe('removeNullAndUndefined', () => {
     it('should remove undefined and null values from an object', () => {
       const obj = {
         name: 'Product 1',

--- a/packages/scraper/src/lib/utils.ts
+++ b/packages/scraper/src/lib/utils.ts
@@ -1,5 +1,4 @@
 import { Image, Product } from '../types';
-import * as cheerio from 'cheerio';
 
 export const mergeProducts = (products: Product[]): Product => {
   const product: Product = {
@@ -57,28 +56,6 @@ const mergeImages = (baseImages: Image[], newImages: Image[]): Image[] => {
 export const normalizeText = (text?: string | null) => {
   if (!text) return text;
   return text.trim().replace(/\s+/g, ' ').trim();
-};
-
-type Selector = { selector: string; attribute?: string | string[] };
-
-export const findBySelectors = (
-  $: cheerio.CheerioAPI,
-  selectors: Selector[]
-) => {
-  for (const { selector, attribute } of selectors) {
-    const element = $(selector);
-    if (!element.length) continue;
-
-    let value: string | undefined;
-    if (Array.isArray(attribute)) {
-      value = attribute.map((attr) => element.attr(attr)).find(Boolean);
-    } else {
-      value = attribute ? element.attr(attribute) : element.text();
-    }
-
-    if (value) return value.trim();
-  }
-  return undefined;
 };
 
 export const removeNullAndUndefined = (obj: any): Object => {

--- a/packages/scraper/src/microdata.ts
+++ b/packages/scraper/src/microdata.ts
@@ -1,7 +1,8 @@
 import * as cheerio from 'cheerio';
-import { findBySelectors, removeNullAndUndefined } from './lib/utils';
-import { Product, Scraper } from './types';
 import { parseCurrency, parseNum, parseURL } from './lib/parse';
+import { removeNullAndUndefined } from './lib/utils';
+import { findBySelectors } from './selector';
+import { Product, Scraper } from './types';
 
 export default class MicrodataScraper implements Scraper {
   $: cheerio.CheerioAPI;
@@ -74,7 +75,7 @@ export default class MicrodataScraper implements Scraper {
 
     const imageURL = parseURL(image, this.url.hostname);
 
-    const product = {
+    const product: Product = {
       name,
       brand,
       description,
@@ -83,6 +84,6 @@ export default class MicrodataScraper implements Scraper {
       currency: parseCurrency(currency),
     };
 
-    return removeNullAndUndefined(product) as Product;
+    return removeNullAndUndefined(product);
   }
 }

--- a/packages/scraper/src/opengraph.ts
+++ b/packages/scraper/src/opengraph.ts
@@ -1,6 +1,7 @@
 import * as cheerio from 'cheerio';
 import { parseCurrency, parseNum, parseURL } from './lib/parse';
-import { findBySelectors, removeNullAndUndefined } from './lib/utils';
+import { removeNullAndUndefined } from './lib/utils';
+import { findBySelectors } from './selector';
 import { Product, Scraper } from './types';
 
 export default class OpenGraphScraper implements Scraper {

--- a/packages/scraper/src/selector.ts
+++ b/packages/scraper/src/selector.ts
@@ -1,0 +1,25 @@
+import * as cheerio from 'cheerio';
+
+export type Selector = { selector: string; attribute?: string | string[] };
+
+export const findBySelectors = (
+  $: cheerio.CheerioAPI,
+  selectors?: Selector[]
+) => {
+  if (!selectors) return undefined;
+
+  for (const { selector, attribute } of selectors) {
+    const element = $(selector);
+    if (!element.length) continue;
+
+    let value: string | undefined;
+    if (Array.isArray(attribute)) {
+      value = attribute.map((attr) => element.attr(attr)).find(Boolean);
+    } else {
+      value = attribute ? element.attr(attribute) : element.text();
+    }
+
+    if (value) return value.trim();
+  }
+  return undefined;
+};


### PR DESCRIPTION
This PR refactors the `packages/scraper` module to accept external selectors for scraping product details. **The primary motivation behind this change is to allow our extension to fetch selectors dynamically from an API.**

Previously, the scraper relied on hardcoded internal selectors, which required the `apps/extension` to be rebuilt and redeployed with every update to the scraping logic. 

### Selectors

* Refactor the `findBySelector` function into its own file, as it will serve as the core logic for the scraper module.

### Amazon

* Removed the `AmazonScraper` class.
* Instead of class-based logic, the module now exports all site-specific selectors for and be served via an API end point by `apps/web`.

### Test

* Refactored tests to align with the new selector handling logic.
