### PR TITLE
feat(extension): update ProductForm to use redesign

### DIFF
--- a/apps/extension/src/App.css
+++ b/apps/extension/src/App.css
@@ -5,6 +5,5 @@
 }
 
 body {
-  width: 362px;
-  min-height: 600px;
+  width: 410px;
 }

--- a/apps/extension/src/pages/ProductForm/ProductForm.tsx
+++ b/apps/extension/src/pages/ProductForm/ProductForm.tsx
@@ -91,13 +91,13 @@ const ProductForm = ({
 
   return (
     <Form {...form}>
-      <div className='border-b-slate-200 bg-slate-100 px-4 py-3 text-left'>
+      <div className='bg-brand-surface-layer px-4 py-3 text-left'>
         <h1 className='text-xl font-semibold'>Save item</h1>
       </div>
       {!isLoading ? (
         <form
           onSubmit={form.handleSubmit(onSubmit)}
-          className='flex h-full w-full flex-col gap-4 p-4'
+          className='flex h-full w-full flex-col gap-4 p-4 pb-6'
         >
           {/* TODO: use Command, and add list creation inside Select */}
           <div className='flex gap-4'>
@@ -107,7 +107,7 @@ const ProductForm = ({
               render={({ field }) => (
                 <FormItem
                   className={cn(
-                    'max-h-[122px] min-h-[122px] min-w-[122px] max-w-[122px] rounded-md bg-gray-100',
+                    'bg-brand-surface-layer max-h-[116px] min-h-[116px] min-w-[116px] max-w-[116px] rounded-md shadow-sm',
                     !field.value?.length && 'border'
                   )}
                 >
@@ -121,54 +121,53 @@ const ProductForm = ({
                 </FormItem>
               )}
             />
-            <div>
-              <div className='flex w-full flex-col text-left'>
-                <FormField
-                  control={form.control}
-                  name='brand'
-                  render={({ field }) => (
-                    <FormItem>
-                      <Input
-                        className='mb-1.5 h-[unset] border-none p-0 text-base font-bold decoration-blue-500 decoration-2 hover:cursor-pointer hover:underline focus:cursor-auto focus:underline focus-visible:ring-[none]'
-                        onChange={field.onChange}
-                        value={field.value}
-                        placeholder='Brand'
-                      />
-                    </FormItem>
-                  )}
-                />
-                <FormField
-                  control={form.control}
-                  name='name'
-                  render={({ field }) => (
-                    <FormItem>
-                      <Textarea
-                        className='mb-2 max-h-[2.8rem] min-h-[2.8rem] resize-none overflow-ellipsis border-none p-0 text-sm decoration-blue-500 decoration-2 hover:cursor-pointer hover:underline focus:cursor-auto focus:underline focus-visible:ring-[none]'
-                        onChange={field.onChange}
-                        value={field.value}
-                        placeholder='Product Name'
-                        spellCheck={false}
-                      />
-                    </FormItem>
-                  )}
-                />
-              </div>
-              <div className='flex flex-row items-center gap-2'>
+            <div className='flex w-full flex-col gap-2 pt-1 text-left'>
+              <FormField
+                control={form.control}
+                name='brand'
+                render={({ field }) => (
+                  <FormItem>
+                    <Input
+                      className='h-[unset] border-none p-0 text-base font-bold decoration-blue-500 decoration-2 hover:cursor-pointer hover:underline focus:cursor-auto focus:underline focus-visible:ring-[none]'
+                      onChange={field.onChange}
+                      value={field.value}
+                      placeholder='Brand'
+                      spellCheck={false}
+                    />
+                  </FormItem>
+                )}
+              />
+              <FormField
+                control={form.control}
+                name='name'
+                render={({ field }) => (
+                  <FormItem>
+                    <Input
+                      className='text-secondary h-[unset] border-none p-0 text-sm decoration-blue-500 decoration-2 hover:cursor-pointer hover:underline focus:cursor-auto focus:underline focus-visible:ring-[none]'
+                      onChange={field.onChange}
+                      value={field.value}
+                      placeholder='Product Name'
+                      spellCheck={false}
+                    />
+                  </FormItem>
+                )}
+              />
+              <div className='mt-2 flex flex-row items-center justify-start'>
                 <FormField
                   control={form.control}
                   name='currency'
                   render={({ field }) => (
-                    <FormItem className='w-full'>
+                    <FormItem className='w-32'>
                       <Select
                         value={field.value}
                         onValueChange={field.onChange}
                       >
                         <FormControl>
-                          <SelectTrigger className='max-w-[80px]'>
+                          <SelectTrigger className='border-brand-border max-w-[80px]'>
                             <SelectValue />
                           </SelectTrigger>
                         </FormControl>
-                        <SelectContent className='max-h-[300px]'>
+                        <SelectContent className='border-brand-border max-h-[260px]'>
                           {/* TODO: Fix render speed of long list here. using virutalization, react-window, or similar. */}
                           {currencyCodes.map((code) => (
                             <SelectItem key={code} value={code}>
@@ -189,7 +188,7 @@ const ProductForm = ({
                         type='number'
                         min='1'
                         step='any'
-                        className='ml-[-1rem] h-[unset] border-none p-0 text-left text-sm font-semibold decoration-blue-500 decoration-2 hover:cursor-pointer hover:underline focus:cursor-auto focus:underline focus-visible:ring-transparent'
+                        className='h-[unset] border-none p-0 text-left text-sm font-medium decoration-blue-500 decoration-2 hover:cursor-pointer hover:underline focus:cursor-auto focus:underline focus-visible:ring-transparent'
                         onChange={(e) => {
                           if (
                             e.target.value === '.' ||
@@ -200,9 +199,7 @@ const ProductForm = ({
                             e.preventDefault();
                           }
                         }}
-                        value={
-                          field.value ? Number(field.value).toFixed(2) : ''
-                        }
+                        value={field.value ?? ''}
                         placeholder='0.00'
                       />
                     </FormItem>
@@ -216,9 +213,8 @@ const ProductForm = ({
             name='folderId'
             render={({ field }) => (
               <FormItem className='flex w-full flex-col justify-start gap-2 text-left'>
-                <h2 className='text-lg font-medium'>Add to List</h2>
-                <FormLabel className='w-full text-base font-normal'>
-                  My lists
+                <FormLabel className='text-secondary w-full text-sm font-semibold'>
+                  Assign to a category
                 </FormLabel>
                 <div className='flex min-h-[88px] flex-wrap gap-2'>
                   {folders.map(({ name, id }, i) =>
@@ -226,8 +222,13 @@ const ProductForm = ({
                       <Button
                         key={name}
                         value={id}
-                        variant='outline'
-                        className={`w-fit max-w-[9rem] rounded-lg text-sm font-normal ${field.value === id && 'bg-slate-200 hover:bg-slate-300'}`}
+                        variant={
+                          field.value !== id
+                            ? 'brand-outline'
+                            : 'brand-outline-selected'
+                        }
+                        className={`h-9 w-fit max-w-[9rem] truncate rounded-lg px-3 text-sm font-normal`}
+                        title={name}
                         onClick={() => {
                           if (field.value !== id) {
                             field.onChange(id);
@@ -236,17 +237,15 @@ const ProductForm = ({
                           }
                         }}
                       >
-                        <p className='truncate' title={name}>
-                          {name}
-                        </p>
+                        {name}
                       </Button>
                     ) : null
                   )}
                   <Button
-                    variant='outline'
-                    className='w-fit max-w-[9rem] rounded-lg text-sm font-normal'
+                    variant='brand-outline'
+                    className='h-9 w-fit max-w-[9rem] rounded-lg px-3 text-sm font-normal'
                   >
-                    <Plus size={16} className='mr-2' />
+                    <Plus size={16} className='mr-0.5' />
                     Add new
                   </Button>
                 </div>
@@ -277,12 +276,12 @@ const ProductForm = ({
             control={form.control}
             name='description'
             render={({ field }) => (
-              <FormItem className='mb-5 text-left'>
+              <FormItem className='text-left'>
                 <FormLabel className='w-full text-base font-normal'>
                   Notes
                 </FormLabel>
                 <Textarea
-                  className='h-[5rem] resize-none bg-slate-200 text-sm placeholder:text-slate-800'
+                  className='placeholder:text-secondary border-brand-border bg-brand-surface-layer h-[6rem] resize-none rounded-lg text-sm'
                   onChange={field.onChange}
                   value={field.value}
                   placeholder='Add your notes here...'
@@ -291,7 +290,7 @@ const ProductForm = ({
               </FormItem>
             )}
           />
-          <Button className='w-full' type='submit'>
+          <Button className='w-full' variant='brand' type='submit'>
             Save item to Wishify
           </Button>
         </form>

--- a/apps/extension/src/pages/ProductForm/ProductForm.tsx
+++ b/apps/extension/src/pages/ProductForm/ProductForm.tsx
@@ -107,13 +107,13 @@ const ProductForm = ({
               render={({ field }) => (
                 <FormItem
                   className={cn(
-                    'bg-brand-surface-layer max-h-[116px] min-h-[116px] min-w-[116px] max-w-[116px] rounded-md shadow-sm',
-                    !field.value?.length && 'border'
+                    'bg-brand-surface-layer max-h-[116px] min-h-[116px] min-w-[116px] max-w-[116px] rounded-md border shadow-sm',
+                    field.value?.length && 'border-gray-200'
                   )}
                 >
                   {field.value?.length && field.value[0]?.url ? (
                     <img
-                      className='h-full w-full rounded-md border object-cover'
+                      className='h-full w-full rounded-md object-cover'
                       src={field.value[0].url}
                       alt='Image'
                     />

--- a/apps/extension/src/pages/ProductForm/ProductForm.tsx
+++ b/apps/extension/src/pages/ProductForm/ProductForm.tsx
@@ -42,7 +42,7 @@ const apiToForm = (product: ScrapedProduct) => ({
   brand: product?.brand ?? '',
   url: product.url ?? '',
   currency: product.currency ?? 'CAD',
-  price: product.price ?? 0.0,
+  ...(product.price ? { price: product.price } : {}),
   ...(product.images?.length && product.images[0]
     ? { images: [product.images[0]] }
     : {}),
@@ -157,7 +157,7 @@ const ProductForm = ({
                   control={form.control}
                   name='currency'
                   render={({ field }) => (
-                    <FormItem className='w-32'>
+                    <FormItem className='mr-3 w-24'>
                       <Select
                         value={field.value}
                         onValueChange={field.onChange}

--- a/apps/extension/src/pages/ProductForm/ProductFormLoading.tsx
+++ b/apps/extension/src/pages/ProductForm/ProductFormLoading.tsx
@@ -2,13 +2,13 @@ import { Skeleton } from '@repo/ui/components/skeleton';
 
 const ProductFormLoading = () => {
   return (
-    <div className='flex flex-col gap-4 p-4'>
-      <div className='flex gap-4'>
-        <Skeleton className='h-[122px] w-[122px] rounded-md' />
+    <div className='flex flex-col gap-3 p-4'>
+      <div className='mb-1 flex gap-4'>
+        <Skeleton className='h-[116px] w-[116px] rounded-md' />
         <div>
           <div className='flex flex-col gap-2'>
             <Skeleton className='h-6 w-full max-w-[280px] rounded-md' />
-            <Skeleton className='mb-4 h-6 w-full max-w-[280px] rounded-md pb-2' />
+            <Skeleton className='mb-1 h-6 w-full max-w-[280px] rounded-md pb-2' />
           </div>
           <div className='mt-2 flex items-center gap-2'>
             <Skeleton className='h-10 w-[80px] rounded-md' />
@@ -16,21 +16,20 @@ const ProductFormLoading = () => {
           </div>
         </div>
       </div>
-
       <div className='flex flex-col gap-2'>
-        <Skeleton className='mb-3 h-6 w-24 rounded-md' />
-        <Skeleton className='mb-2 h-6 w-16 rounded-md' />
+        {/* <Skeleton className='mb-3 h-6 w-24 rounded-md' /> */}
+        <Skeleton className='mb-2 h-6 w-36 rounded-md' />
         <div className='flex flex-wrap gap-2'>
           {Array(3)
             .fill(null)
             .map((_, idx) => (
               <Skeleton key={idx} className='h-10 w-24 rounded-lg' />
             ))}
-          <Skeleton className='h-10 w-[7.5rem] rounded-lg' />
         </div>
+        <Skeleton className='h-10 w-[7.5rem] rounded-lg' />
       </div>
-      <Skeleton className='h-6 w-16 rounded-md' />
-      <Skeleton className='mb-3 h-[5rem] w-full rounded-md' />
+      <Skeleton className='h-6 w-14 rounded-md' />
+      <Skeleton className='mb-6 h-[5rem] w-full rounded-md' />
       <Skeleton className='h-10 w-full rounded-md' />
     </div>
   );

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,9 @@
         "apps/*",
         "packages/*"
       ],
+      "dependencies": {
+        "@fontsource/inter": "^5.1.0"
+      },
       "devDependencies": {
         "prettier": "^3.4.1",
         "prettier-plugin-tailwindcss": "^0.6.9",
@@ -1794,6 +1797,11 @@
       "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.8.tgz",
       "integrity": "sha512-kym7SodPp8/wloecOpcmSnWJsK7M0E5Wg8UcFA+uO4B9s5d0ywXOEro/8HM9x0rW+TljRzul/14UYz3TleT3ig==",
       "license": "MIT"
+    },
+    "node_modules/@fontsource/inter": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@fontsource/inter/-/inter-5.1.0.tgz",
+      "integrity": "sha512-zKZR3kf1G0noIes1frLfOHP5EXVVm0M7sV/l9f/AaYf+M/DId35FO4LkigWjqWYjTJZGgplhdv4cB+ssvCqr5A=="
     },
     "node_modules/@hookform/resolvers": {
       "version": "3.9.1",
@@ -12925,7 +12933,6 @@
       "resolved": "https://registry.npmjs.org/prettier-plugin-tailwindcss/-/prettier-plugin-tailwindcss-0.6.9.tgz",
       "integrity": "sha512-r0i3uhaZAXYP0At5xGfJH876W3HHGHDp+LCRUJrs57PBeQ6mYHMwr25KH8NPX44F2yGTvdnH7OqCshlQx183Eg==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=14.21.3"
       },

--- a/package.json
+++ b/package.json
@@ -20,5 +20,8 @@
   "workspaces": [
     "apps/*",
     "packages/*"
-  ]
+  ],
+  "dependencies": {
+    "@fontsource/inter": "^5.1.0"
+  }
 }

--- a/packages/ui/src/components/button.tsx
+++ b/packages/ui/src/components/button.tsx
@@ -1,56 +1,62 @@
-import * as React from "react"
-import { Slot } from "@radix-ui/react-slot"
-import { cva, type VariantProps } from "class-variance-authority"
+import * as React from 'react';
+import { Slot } from '@radix-ui/react-slot';
+import { cva, type VariantProps } from 'class-variance-authority';
 
-import { cn } from "@repo/ui/lib/utils"
+import { cn } from '@repo/ui/lib/utils';
 
 const buttonVariants = cva(
-  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
+  'inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0',
   {
     variants: {
       variant: {
-        default: "bg-primary text-primary-foreground hover:bg-primary/90",
+        default: 'bg-primary text-primary-foreground hover:bg-primary/90',
         destructive:
-          "bg-destructive text-destructive-foreground hover:bg-destructive/90",
+          'bg-destructive text-destructive-foreground hover:bg-destructive/90',
         outline:
-          "border border-input bg-background hover:bg-accent hover:text-accent-foreground",
+          'border border-input bg-background hover:bg-accent hover:text-accent-foreground',
         secondary:
-          "bg-secondary text-secondary-foreground hover:bg-secondary/80",
-        ghost: "hover:bg-accent hover:text-accent-foreground",
-        link: "text-primary underline-offset-4 hover:underline",
+          'bg-secondary text-secondary-foreground hover:bg-secondary/80',
+        ['brand']:
+          'bg-brand-purple text-primary-foreground hover:bg-brand-purple/90',
+        ['brand-outline']:
+          'border-brand-border border bg-background hover:bg-accent hover:text-accent-foreground text-secondary hover:bg-brand-purple-lighter/40 active:bg-brand-purple-lighter/70',
+        ['brand-outline-selected']:
+          'text-brand-purple-light border-brand-purple-light bg-brand-purple-lighter/40 hover:bg-brand-purple-lighter/70 border border-input border-brand-purple-light',
+        ghost: 'hover:bg-accent hover:text-accent-foreground',
+        link: 'text-primary underline-offset-4 hover:underline',
       },
       size: {
-        default: "h-10 px-4 py-2",
-        sm: "h-9 rounded-md px-3",
-        lg: "h-11 rounded-md px-8",
-        icon: "h-10 w-10",
+        default: 'h-10 px-4 py-2',
+        sm: 'h-9 rounded-md px-3',
+        lg: 'h-11 rounded-md px-8',
+        icon: 'h-10 w-10',
       },
     },
     defaultVariants: {
-      variant: "default",
-      size: "default",
+      variant: 'default',
+      size: 'default',
     },
   }
-)
+);
 
 export interface ButtonProps
   extends React.ButtonHTMLAttributes<HTMLButtonElement>,
     VariantProps<typeof buttonVariants> {
-  asChild?: boolean
+  asChild?: boolean;
 }
 
 const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
   ({ className, variant, size, asChild = false, ...props }, ref) => {
-    const Comp = asChild ? Slot : "button"
+    const Comp = asChild ? Slot : 'button';
     return (
       <Comp
         className={cn(buttonVariants({ variant, size, className }))}
         ref={ref}
         {...props}
       />
-    )
+    );
   }
-)
-Button.displayName = "Button"
+);
+Button.displayName = 'Button';
 
-export { Button, buttonVariants }
+export { Button, buttonVariants };

--- a/packages/ui/src/globals.css
+++ b/packages/ui/src/globals.css
@@ -12,7 +12,7 @@
     --popover-foreground: 240 10% 3.9%;
     --primary: 240 5.9% 10%;
     --primary-foreground: 0 0% 98%;
-    --secondary: 240 4.8% 95.9%;
+    --secondary: 230 9% 27%;
     --secondary-foreground: 240 5.9% 10%;
     --muted: 240 4.8% 95.9%;
     --muted-foreground: 240 3.8% 46.1%;
@@ -20,6 +20,11 @@
     --accent-foreground: 240 5.9% 10%;
     --destructive: 0 84.2% 60.2%;
     --destructive-foreground: 0 0% 98%;
+    --brand-purple: 252 81% 40%;
+    --brand-purple-light: 254 76% 47%;
+    --brand-purple-lighter: 248 85% 84%;
+    --brand-border: 236 13% 75%;
+    --brand-surface-layer: 240 100% 98%;
     --border: 240 5.9% 90%;
     --input: 240 5.9% 90%;
     --ring: 240 5.9% 10%;

--- a/packages/ui/tailwind.config.ts
+++ b/packages/ui/tailwind.config.ts
@@ -1,5 +1,6 @@
 import type { Config } from 'tailwindcss';
 import tailwindcssAnimate from 'tailwindcss-animate';
+import defaultTheme from 'tailwindcss/defaultTheme';
 
 const config = {
   darkMode: ['class'],
@@ -12,6 +13,9 @@ const config = {
   ],
   prefix: '',
   theme: {
+    fontFamily: {
+      sans: ['Inter', ...defaultTheme.fontFamily.sans],
+    },
     container: {
       center: true,
       padding: '2rem',
@@ -21,7 +25,7 @@ const config = {
     },
     extend: {
       colors: {
-        border: 'hsl(var(--border))',
+        border: 'hsl(var(--brand-border-gray))',
         input: 'hsl(var(--input))',
         ring: 'hsl(var(--ring))',
         background: 'hsl(var(--background))',
@@ -45,6 +49,15 @@ const config = {
         accent: {
           DEFAULT: 'hsl(var(--accent))',
           foreground: 'hsl(var(--accent-foreground))',
+        },
+        brand: {
+          purple: {
+            DEFAULT: 'hsl(var(--brand-purple))',
+            light: 'hsl(var(--brand-purple-light))',
+            lighter: 'hsl(var(--brand-purple-lighter))',
+          },
+          border: 'hsl(var(--brand-border))',
+          'surface-layer': 'hsl(var(--brand-surface-layer))',
         },
         popover: {
           DEFAULT: 'hsl(var(--popover))',


### PR DESCRIPTION
### This PR redesigns the extension's Product form to use the latest redesign from Figma.
-  Add styles + colours to Tailwind config, including 'Inter' font, button variants, colours
- Update ProductForm UI, loading skeleton

Extension Popup:

<img width="947" alt="image" src="https://github.com/user-attachments/assets/2c40a8c6-1e31-4a5e-943c-dc7d5b3d0747">


Blank:

<img width="352" alt="image" src="https://github.com/user-attachments/assets/c7e556a1-f550-4013-a42c-718f9aee8cf3">
